### PR TITLE
카카오 로그인 후 CASE 값 반환

### DIFF
--- a/monitoring/prometheus/config/prometheus.yml
+++ b/monitoring/prometheus/config/prometheus.yml
@@ -5,4 +5,4 @@ scrape_configs:
   - job_name: "galaxy"
     metrics_path: "/actuator/prometheus"
     static_configs:
-      - targets: [ "52.78.187.236:8080" ]
+      - targets: [ "54.180.195.94:8080" ]

--- a/src/main/java/com/balybus/galaxy/login/oauth/domain/type/CaseType.java
+++ b/src/main/java/com/balybus/galaxy/login/oauth/domain/type/CaseType.java
@@ -1,0 +1,25 @@
+package com.balybus.galaxy.login.oauth.domain.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum CaseType {
+    CASE1("CASE1", "첫 번째 케이스"),
+    CASE2("CASE2", "두 번째 케이스"),
+    CASE3("CASE3"," 세 번째 케이스"),
+    CASE4("CASE4", "네 번째 케이스");
+
+    private final String code;
+    private final String caseNum;
+
+    public static CaseType of(String code) {
+        return Arrays.stream(CaseType.values())
+                .filter(r -> r.getCode().equals(code))
+                .findAny()
+                .orElse(CASE4);
+    }
+}

--- a/src/main/java/com/balybus/galaxy/login/oauth/dto/response/KakaoResponse.java
+++ b/src/main/java/com/balybus/galaxy/login/oauth/dto/response/KakaoResponse.java
@@ -1,6 +1,7 @@
 package com.balybus.galaxy.login.oauth.dto.response;
 
 import com.balybus.galaxy.login.classic.domain.type.RoleType;
+import com.balybus.galaxy.login.oauth.domain.type.CaseType;
 import com.balybus.galaxy.member.domain.type.LoginType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,4 +16,5 @@ public class KakaoResponse {
     private LoginType loginType;
     private RoleType roleType;
     private String description;
+    private CaseType caseType;
 }

--- a/src/main/java/com/balybus/galaxy/member/dto/request/MemberRequest.java
+++ b/src/main/java/com/balybus/galaxy/member/dto/request/MemberRequest.java
@@ -1,5 +1,6 @@
 package com.balybus.galaxy.member.dto.request;
 
+import com.balybus.galaxy.login.oauth.domain.type.CaseType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   profiles:
     active: dev
-    include: db, oauth, jwt, mail, aws
+    include: db, oauth, jwt, mail, aws, oauth
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
```java
https://kauth.kakao.com/oauth/authorize?client_id=bf075c0ef5f97b46c4f60fe71e1efbb4&redirect_uri=http://localhost:8080/login/oauth2/code/kakao&response_type=code&scope=profile_nickname,profile_image,account_email
```

위 url로 접속하여 카카오 로그인 후 얻은 code값을 body에 실어 보내주세요!

- request body

```java
{
    "code": "kwPpu1vZ4Rmy_PQsAg9-g0aZYF6dloJ28fknGv5CrK6xyoKXhpw1xAAAAAQKDQgeAAABl-SFGQWm1x-HnlkNwQ",
    "RoleType": "MEMBER"
}
```

- response body

```java
{
    "email": "manuna530@gmail.com",
    "nickName": "김준희",
    "loginType": "KAKAO_LOGIN",
    "roleType": null,
    "description": "카카오 연동 정보는 있으나, 우리 서비스 회원 정보가 없습니다. 회원가입을 진행해 주세요.",
    "caseType": "CASE3"
}
```

각 케이스 타입별로 반환값이 달라집니다.

- CASE1

`케이스 1: 카카오 연동 정보는 없으나, 우리 서비스에 동일 이메일로 가입된 회원이 있는 경우// -> 기존 아이디로 자동 로그인 시키기 (카카오 계정과 기존 계정 자동 연동 및 로그인)`

- CASE2

`케이스 2: 카카오 연동 정보도 없고, 우리 서비스 회원 정보도 없는 경우 (완전 신규)// -> 카카오 정보를 TblKakao에 저장하고, 프론트에 추가 회원가입 진행 안내`

- CASE3

`케이스 3: 카카오 연동 정보는 있으나, 우리 서비스 회원 정보가 없는 경우// (예: 과거에 카카오로 우리 서비스에 접근 시도했으나, 회원가입을 완료하지 않은 경우 또는 다른 경로로 TblKakao만 생성된 경우)// -> 프론트에 추가 회원가입 진행 안내 (TblKakao 정보는 이미 있으므로 업데이트 또는 그대로 사용)`

- CASE4

`케이스 4: 카카오 연동 정보도 있고, 우리 서비스 회원 정보도 있는 경우 (이미 연동된 기존 회원)// -> 카카오 계정 기반으로 로그인 처리`